### PR TITLE
fix at_hash validation for servers that provide null at_hash at refresh

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -839,7 +839,7 @@ class BaseClient {
       });
     }
 
-    if (tokenSet.access_token && payload.at_hash !== undefined) {
+    if (tokenSet.access_token && payload.at_hash !== undefined && payload.at_hash !== null) {
       try {
         tokenHash.validate(
           { claim: 'at_hash', source: 'access_token' },


### PR DESCRIPTION
Some ipenid servers (namely Authentik) don't provide at_hash on refresh and instead of dropping the key from payload — are setting it to null. This is breaking validation. This commit ads null check